### PR TITLE
Fix a crash when a sharing violation occurs during --info

### DIFF
--- a/Test/Printer.cs
+++ b/Test/Printer.cs
@@ -49,60 +49,68 @@ namespace Test
         {
             Console.WriteLine($"Attempting to print info for {file}");
 
-            using Stream stream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-
-            // Read the first 8 bytes
-            byte[]? magic = stream.ReadBytes(8);
-            stream.Seek(0, SeekOrigin.Begin);
-
-            // Get the file type
-            SupportedFileType ft = FileTypes.GetFileType(magic ?? []);
-            if (ft == SupportedFileType.UNKNOWN)
+            try
             {
-                string extension = Path.GetExtension(file).TrimStart('.');
-                ft = FileTypes.GetFileType(extension);
-            }
+                using Stream stream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
-            // Print out the file format
-            Console.WriteLine($"File format found: {ft}");
+                // Read the first 8 bytes
+                byte[]? magic = stream.ReadBytes(8);
+                stream.Seek(0, SeekOrigin.Begin);
 
-            // Setup the wrapper to print
-            var wrapper = WrapperFactory.CreateWrapper(ft, stream);
+                // Get the file type
+                SupportedFileType ft = FileTypes.GetFileType(magic ?? []);
+                if (ft == SupportedFileType.UNKNOWN)
+                {
+                    string extension = Path.GetExtension(file).TrimStart('.');
+                    ft = FileTypes.GetFileType(extension);
+                }
 
-            // If we don't have a wrapper
-            if (wrapper == null)
-            {
-                Console.WriteLine($"Either {ft} is not supported or something went wrong during parsing!");
-                Console.WriteLine();
-                return;
-            }
+                // Print out the file format
+                Console.WriteLine($"File format found: {ft}");
 
-            // Print the wrapper name
-            Console.WriteLine($"{wrapper.Description()} wrapper created successfully!");
+                // Setup the wrapper to print
+                var wrapper = WrapperFactory.CreateWrapper(ft, stream);
 
-            // Get the base info output name
-            string filenameBase = $"info-{DateTime.Now:yyyy-MM-dd_HHmmss.ffff}";
+                // If we don't have a wrapper
+                if (wrapper == null)
+                {
+                    Console.WriteLine($"Either {ft} is not supported or something went wrong during parsing!");
+                    Console.WriteLine();
+                    return;
+                }
+
+                // Print the wrapper name
+                Console.WriteLine($"{wrapper.Description()} wrapper created successfully!");
+
+                // Get the base info output name
+                string filenameBase = $"info-{DateTime.Now:yyyy-MM-dd_HHmmss.ffff}";
 
 #if NET6_0_OR_GREATER
-                // If we have the JSON flag
-                if (json)
-                {
-                    // Create the output data
-                    string serializedData = wrapper.ExportJSON();
-                    Console.WriteLine(serializedData);
+                    // If we have the JSON flag
+                    if (json)
+                    {
+                        // Create the output data
+                        string serializedData = wrapper.ExportJSON();
+                        Console.WriteLine(serializedData);
 
-                    // Write the output data
-                    using var jsw = new StreamWriter(File.OpenWrite($"{filenameBase}.json"));
-                    jsw.WriteLine(serializedData);
-                }
+                        // Write the output data
+                        using var jsw = new StreamWriter(File.OpenWrite($"{filenameBase}.json"));
+                        jsw.WriteLine(serializedData);
+                    }
 #endif
-            // Create the output data
-            var builder = wrapper.PrettyPrint();
-            Console.WriteLine(builder);
+                // Create the output data
+                var builder = wrapper.PrettyPrint();
+                Console.WriteLine(builder);
 
-            // Write the output data
-            using var sw = new StreamWriter(File.OpenWrite($"{filenameBase}.txt"));
-            sw.WriteLine(builder.ToString());
+                // Write the output data
+                using var sw = new StreamWriter(File.OpenWrite($"{filenameBase}.txt"));
+                sw.WriteLine(builder.ToString());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(debug ? ex : "[Exception opening file, please try again]");
+                Console.WriteLine();
+            }
         }
 
         #region Printing Implementations


### PR DESCRIPTION
I was running a scan with `--info` on a directory where an open IDA database resided, and BOS crashed on a sharing violation when attempting to open those files. I modified `PrintFileInfo` to deal with failure the same way `GetInternalProtections` does.