### PR TITLE
Fix WinZip SFX folders not being scanned

### DIFF
--- a/BinaryObjectScanner/FileType/PKZIP.cs
+++ b/BinaryObjectScanner/FileType/PKZIP.cs
@@ -46,6 +46,10 @@ namespace BinaryObjectScanner.FileType
                             if (entry.IsDirectory)
                                 continue;
 
+                            // If we have a partial entry due to an incomplete multi-part archive, skip it
+                            if (!entry.IsComplete)
+                                continue;
+
                             string tempFile = Path.Combine(tempPath, entry.Key);
                             var directoryName = Path.GetDirectoryName(tempFile);
                             if (directoryName != null && !Directory.Exists(directoryName))

--- a/BinaryObjectScanner/Packer/WinZipSFX.cs
+++ b/BinaryObjectScanner/Packer/WinZipSFX.cs
@@ -93,6 +93,10 @@ namespace BinaryObjectScanner.Packer
                             if (entry.IsDirectory)
                                 continue;
 
+                            // If we have a partial entry due to an incomplete multi-part archive, skip it
+                            if (!entry.IsComplete)
+                                continue;
+
                             string tempFile = Path.Combine(tempPath, entry.Key);
                             var directoryName = Path.GetDirectoryName(tempFile);
                             if (directoryName != null && !Directory.Exists(directoryName))

--- a/BinaryObjectScanner/Packer/WinZipSFX.cs
+++ b/BinaryObjectScanner/Packer/WinZipSFX.cs
@@ -73,20 +73,21 @@ namespace BinaryObjectScanner.Packer
         /// <summary>
         /// Handle common extraction between executable types
         /// </summary>
-        private static string? Extract(string file, bool includeDebug)
+        /// <inheritdoc/>
+        public string? Extract(string file, bool includeDebug)
         {
+            if (file == null)
+                return null;
+
 #if NET462_OR_GREATER || NETCOREAPP
             try
             {
-                // Should be using stream instead of file, but stream fails to extract anything. My guess is that the executable portion of the archive is causing stream to fail, but not file.
+                // Create a temp output directory
+                string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                Directory.CreateDirectory(tempPath);
+
                 using (ZipArchive zipFile = ZipArchive.Open(file))
                 {
-                    if (!zipFile.IsComplete)
-                        return null;
-
-                    string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-                    Directory.CreateDirectory(tempPath);
-
                     foreach (var entry in zipFile.Entries)
                     {
                         try
@@ -96,6 +97,9 @@ namespace BinaryObjectScanner.Packer
                                 continue;
 
                             string tempFile = Path.Combine(tempPath, entry.Key);
+                            var directoryName = Path.GetDirectoryName(tempFile);
+                            if (directoryName != null && !Directory.Exists(directoryName))
+                                Directory.CreateDirectory(directoryName);
                             entry.WriteToFile(tempFile);
                         }
                         catch (Exception ex)
@@ -103,9 +107,9 @@ namespace BinaryObjectScanner.Packer
                             if (includeDebug) Console.WriteLine(ex);
                         }
                     }
-
-                    return tempPath;
                 }
+
+                return tempPath;
             }
             catch (Exception ex)
             {

--- a/BinaryObjectScanner/Packer/WinZipSFX.cs
+++ b/BinaryObjectScanner/Packer/WinZipSFX.cs
@@ -76,9 +76,6 @@ namespace BinaryObjectScanner.Packer
         /// <inheritdoc/>
         public string? Extract(string file, bool includeDebug)
         {
-            if (file == null)
-                return null;
-
 #if NET462_OR_GREATER || NETCOREAPP
             try
             {


### PR DESCRIPTION
Use PKZIP extraction to fix WinZip SFX extraction not extracting folders.