### PR TITLE
Fix SecuRom subsubversion number writing second digit to first digit

### DIFF
--- a/BinaryObjectScanner/Protection/SecuROM.cs
+++ b/BinaryObjectScanner/Protection/SecuROM.cs
@@ -205,7 +205,7 @@ namespace BinaryObjectScanner.Protection
             byte[] subSubVersion = new byte[2];
             subSubVersion[0] = (byte)(fileContent[index] ^ 42);
             index++;
-            subSubVersion[0] = (byte)(fileContent[index] ^ 8);
+            subSubVersion[1] = (byte)(fileContent[index] ^ 8);
             index += 2;
 
             byte[] subSubSubVersion = new byte[4];


### PR DESCRIPTION
Fixes http://redump.org/disc/38816/ and others being detected as 5.03.60 instead of 5.03.06.