### PR TITLE
Fix scans that use directory name in Windows

### DIFF
--- a/BinaryObjectScanner/Protection/Channelware.cs
+++ b/BinaryObjectScanner/Protection/Channelware.cs
@@ -82,7 +82,11 @@ namespace BinaryObjectScanner.Protection
                 new(new FilePathMatch("chanwr.ini"), "Channelware"),
                 new(new FilePathMatch("CWAuto.dll"), "Channelware"),
 
-                // TODO: Add check for "CWare" and "cware" folders.
+                // Found in Redump entry 116358.
+                new(Path.Combine("CWare", "install.exe"), "Channelware"),
+
+                // Found in Redump entry 12354.
+                new(Path.Combine("cware", "Install.exe"), "Channelware"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -104,7 +108,11 @@ namespace BinaryObjectScanner.Protection
                 new(new FilePathMatch("chanwr.ini"), "Channelware"),
                 new(new FilePathMatch("CWAuto.dll"), "Channelware"),
 
-                // TODO: Add check for "CWare" and "cware" folders.
+                // Found in Redump entry 116358.
+                new(Path.Combine("CWare", "install.exe"), "Channelware"),
+
+                // Found in Redump entry 12354.
+                new(Path.Combine("cware", "Install.exe"), "Channelware"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BinaryObjectScanner/Protection/LabelGate.cs
+++ b/BinaryObjectScanner/Protection/LabelGate.cs
@@ -63,20 +63,20 @@ namespace BinaryObjectScanner.Protection
                 new(new List<PathMatch>
                 {
 #if NET20 || NET35
-                    new(Path.Combine(Path.Combine("BIN", "WIN32"), "MQ2SETUP.EXE").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine(Path.Combine("BIN", "WIN32"), "MQSTART.EXE").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine(Path.Combine("BIN", "WIN32"), "MQ2SETUP.EXE")),
+                    new(Path.Combine(Path.Combine("BIN", "WIN32"), "MQSTART.EXE")),
 #else
-                    new(Path.Combine("BIN", "WIN32", "MQ2SETUP.EXE").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine("BIN", "WIN32", "MQSTART.EXE").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("BIN", "WIN32", "MQ2SETUP.EXE")),
+                    new(Path.Combine("BIN", "WIN32", "MQSTART.EXE")),
 #endif
                 }, "LabelGate CD2 Media Player"),
 
                 // All of these are also found present on all known LabelGate CD2 releases, though an additional file "RESERVED.DAT" is found in the same directory in at least one release (Product ID SVWC-7185)
                 new(new List<PathMatch>
                 {
-                    new(Path.Combine("MQDISC", "LICENSE.TXT").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine("MQDISC", "MQDISC.INI").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine("MQDISC", "START.INI").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("MQDISC", "LICENSE.TXT")),
+                    new(Path.Combine("MQDISC", "MQDISC.INI")),
+                    new(Path.Combine("MQDISC", "START.INI")),
                 }, "LabelGate CD2"),
             };
 

--- a/BinaryObjectScanner/Protection/OpenMG.cs
+++ b/BinaryObjectScanner/Protection/OpenMG.cs
@@ -79,10 +79,10 @@ namespace BinaryObjectScanner.Protection
                 // TODO: Investigate the consistency of "\OMGEXTRA\INDX0000.XML" and "\OMGEXTRA\INDX0001.XML", they seem to only appear when bonus content is present ("Touch" by Amerie).
                 new(new List<PathMatch>
                 {
-                    new(Path.Combine("OMGAUDIO", "00AUDTOC.DAT").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine("OMGAUDIO", "01AUDSTR.DAT").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine("OMGAUDIO", "05SRPCDS.DAT").Replace("\\", "/"), useEndsWith: true),
-                    new(Path.Combine("OMGEXTRA", "OMGSVC.DAT").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("OMGAUDIO", "00AUDTOC.DAT")),
+                    new(Path.Combine("OMGAUDIO", "01AUDSTR.DAT")),
+                    new(Path.Combine("OMGAUDIO", "05SRPCDS.DAT")),
+                    new(Path.Combine("OMGEXTRA", "OMGSVC.DAT")),
                 }, "OpenMG"),
 
                 // Always found together on OpenMG releases ("Touch" by Amerie, Redump entry 95010, and product ID SVWC-7185).

--- a/BinaryObjectScanner/Protection/Tages.cs
+++ b/BinaryObjectScanner/Protection/Tages.cs
@@ -76,10 +76,10 @@ namespace BinaryObjectScanner.ProtectionType
                 new(new List<PathMatch>
                 {
                     // d37f70489207014d7d0fbaa43b081a93e8030498
-                    new(Path.Combine("Sys", "Devx.sys").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("Sys", "Devx.sys")),
 
                     // a0acbc2f8e321e4f30c913c095e28af444058249
-                    new(Path.Combine("Sys", "VtPr.sys").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("Sys", "VtPr.sys")),
 
                     // SHA-1 is variable, file size is 81,920 bytes
                     new FilePathMatch("Wave.aif"),
@@ -99,16 +99,16 @@ namespace BinaryObjectScanner.ProtectionType
                 new(new List<PathMatch>
                 {
                     // f82339d797be6da92f5d9dadeae9025385159057
-                    new(Path.Combine("9x", "Tamlx.alf").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("9x", "Tamlx.alf")),
 
                     // 933c004d3043863f019f5ffaf63402a30e65026c
-                    new(Path.Combine("9x", "Tamlx.apt").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("9x", "Tamlx.apt")),
 
                     // d45745fa6b0d23fe0ee12e330ab85d5bf4e0e776
-                    new(Path.Combine("NT", "enodpl.sys").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("NT", "enodpl.sys")),
 
                     // f111eba05ca6e9061c557547420847d7fdee657d
-                    new(Path.Combine("NT", "litdpl.sys").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("NT", "litdpl.sys")),
                 }, "TAGES"),
 
                 // Currently only known to exist in "XIII" and "Beyond Good & Evil" (Redump entries 8774-8776, 45940-45941, 18690-18693, and presumably 21320, 21321, 21323, and 36124).
@@ -127,16 +127,16 @@ namespace BinaryObjectScanner.ProtectionType
                 new(new List<PathMatch>
                 {
                     // 40826e95f3ad8031b6debe15aca052c701288e04
-                    new(Path.Combine("9x", "hwpsgt.vxd").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("9x", "hwpsgt.vxd")),
 
                     // f82339d797be6da92f5d9dadeae9025385159057
-                    new(Path.Combine("9x", "lemsgt.vxd").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("9x", "lemsgt.vxd")),
 
                     // 43f407ecdc0d87a3713126b757ccaad07ade285f
-                    new(Path.Combine("NT", "hwpsgt.sys").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("NT", "hwpsgt.sys")),
 
                     // 548dd6359abbcc8c84ce346d078664eeedc716f7
-                    new(Path.Combine("NT", "lemsgt.sys").Replace("\\", "/"), useEndsWith: true),
+                    new(Path.Combine("NT", "lemsgt.sys")),
                 }, "TAGES"),
 
                 // The following files are supposed to only be found inside the driver setup executables, and are present in at least version 5.2.0.1 (Redump entry 15976).

--- a/BinaryObjectScanner/Protection/TivolaRingProtection.cs
+++ b/BinaryObjectScanner/Protection/TivolaRingProtection.cs
@@ -22,7 +22,7 @@ namespace BinaryObjectScanner.Protection
         {
             var matchers = new List<PathMatchSet>
             {
-                new(Path.Combine("ZDAT", "webmast.dxx").Replace("\\", "/"), "Tivola Ring Protection [Check disc for physical ring]"),
+                new(Path.Combine("ZDAT", "webmast.dxx"), "Tivola Ring Protection [Check disc for physical ring]"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -33,7 +33,7 @@ namespace BinaryObjectScanner.Protection
         {
             var matchers = new List<PathMatchSet>
             {
-                new(Path.Combine("ZDAT", "webmast.dxx").Replace("\\", "/"), "Tivola Ring Protection [Check disc for physical ring]"),
+                new(Path.Combine("ZDAT", "webmast.dxx"), "Tivola Ring Protection [Check disc for physical ring]"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BinaryObjectScanner/Protection/Zzxzz.cs
+++ b/BinaryObjectScanner/Protection/Zzxzz.cs
@@ -21,9 +21,9 @@ namespace BinaryObjectScanner.Protection
             var matchers = new List<PathMatchSet>
             {
 #if NET20 || NET35
-                new(Path.Combine(Path.Combine(path, "Zzxzz"), "Zzz.aze").Replace("\\", "/"), "Zzxzz"),
+                new(Path.Combine(Path.Combine(path, "Zzxzz"), "Zzz.aze"), "Zzxzz"),
 #else
-                new(Path.Combine(path, "Zzxzz", "Zzz.aze").Replace("\\", "/"), "Zzxzz"),
+                new(Path.Combine(path, "Zzxzz", "Zzz.aze"), "Zzxzz"),
 #endif
                 new($"Zzxzz/", "Zzxzz"),
             };


### PR DESCRIPTION
Removes ``.Replace("\\", "/")``, as it was messing with folder paths on Windows. Confirmed to still work on Linux as well.