### PR TITLE
Update SharpCompress to 0.38.0

### DIFF
--- a/BinaryObjectScanner/BinaryObjectScanner.csproj
+++ b/BinaryObjectScanner/BinaryObjectScanner.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="OpenMcdf" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.StartsWith(`net2`)) AND !$(TargetFramework.StartsWith(`net3`)) AND !$(TargetFramework.StartsWith(`net40`)) AND !$(TargetFramework.StartsWith(`net452`))">
-    <PackageReference Include="SharpCompress" Version="0.37.2" />
+    <PackageReference Include="SharpCompress" Version="0.38.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith(`net4`)) AND !$(TargetFramework.StartsWith(`net40`))">


### PR DESCRIPTION
Adds significant amount of relevant fixes and additions, including support for 7-zip SFX, which would make implementing support for it in BOS more purposeful. 

https://github.com/adamhathcock/sharpcompress/releases/tag/0.38.0