### PR TITLE
[WIP] Add 7-Zip SFX extraction

### DIFF
--- a/BinaryObjectScanner/Packer/SevenZipSFX.cs
+++ b/BinaryObjectScanner/Packer/SevenZipSFX.cs
@@ -56,18 +56,13 @@ namespace BinaryObjectScanner.Packer
             if (!File.Exists(file))
                 return null;
 
-            using var stream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-
-            if (stream == null)
-                return null;
-
 #if NET462_OR_GREATER || NETCOREAPP
             try
             {
                 // Create a temp output directory
                 string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                 Directory.CreateDirectory(tempPath);
-                using (SevenZipArchive sevenZipFile = SevenZipArchive.Open(stream, new ReaderOptions() { LookForHeader = true }))
+                using (SevenZipArchive sevenZipFile = SevenZipArchive.Open(file, new ReaderOptions() { LookForHeader = true }))
                 {
                     foreach (var entry in sevenZipFile.Entries)
                     {

--- a/BinaryObjectScanner/Packer/SevenZipSFX.cs
+++ b/BinaryObjectScanner/Packer/SevenZipSFX.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using BinaryObjectScanner.Interfaces;
 using SabreTools.Serialization.Wrappers;
 #if NET462_OR_GREATER || NETCOREAPP

--- a/BinaryObjectScanner/Packer/SevenZipSFX.cs
+++ b/BinaryObjectScanner/Packer/SevenZipSFX.cs
@@ -1,10 +1,17 @@
+using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using BinaryObjectScanner.Interfaces;
 using SabreTools.Serialization.Wrappers;
+#if NET462_OR_GREATER || NETCOREAPP
+using SharpCompress.Archives;
+using SharpCompress.Archives.SevenZip;
+using SharpCompress.Readers;
+#endif
 
 namespace BinaryObjectScanner.Packer
 {
-    // TODO: Add extraction
     public class SevenZipSFX : IExtractablePortableExecutable, IPortableExecutableCheck
     {
         /// <inheritdoc/>
@@ -46,8 +53,64 @@ namespace BinaryObjectScanner.Packer
 
         /// <inheritdoc/>
         public string? Extract(string file, PortableExecutable pex, bool includeDebug)
+            => Extract(file, includeDebug);
+
+        /// <inheritdoc/>
+        public string? Extract(string file, bool includeDebug)
         {
+            if (!File.Exists(file))
+                return null;
+
+            using var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return Extract(fs, file, includeDebug);
+        }
+
+        /// <inheritdoc/>
+        public string? Extract(Stream? stream, string file, bool includeDebug)
+        {
+            if (stream == null)
+                return null;
+
+#if NET462_OR_GREATER || NETCOREAPP
+            try
+            {
+                // Create a temp output directory
+                string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                Directory.CreateDirectory(tempPath);
+                using (SevenZipArchive sevenZipFile = SevenZipArchive.Open(stream, new ReaderOptions() { LookForHeader = true }))
+                {
+                    foreach (var entry in sevenZipFile.Entries)
+                    {
+                        try
+                        {
+                            // If the entry is a directory
+                            if (entry.IsDirectory)
+                                continue;
+
+                            // If the entry has an invalid key
+                            if (entry.Key == null)
+                                continue;
+
+                            string tempFile = Path.Combine(tempPath, entry.Key);
+                            entry.WriteToFile(tempFile);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (includeDebug) Console.WriteLine(ex);
+                        }
+                    }
+                }
+
+                return tempPath;
+            }
+            catch (Exception ex)
+            {
+                if (includeDebug) Console.WriteLine(ex);
+                return null;
+            }
+#else
             return null;
+#endif
         }
     }
 }

--- a/BinaryObjectScanner/Packer/SevenZipSFX.cs
+++ b/BinaryObjectScanner/Packer/SevenZipSFX.cs
@@ -53,21 +53,12 @@ namespace BinaryObjectScanner.Packer
 
         /// <inheritdoc/>
         public string? Extract(string file, PortableExecutable pex, bool includeDebug)
-            => Extract(file, includeDebug);
-
-        /// <inheritdoc/>
-        public string? Extract(string file, bool includeDebug)
         {
             if (!File.Exists(file))
                 return null;
 
-            using var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            return Extract(fs, file, includeDebug);
-        }
+            using var stream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
-        /// <inheritdoc/>
-        public string? Extract(Stream? stream, string file, bool includeDebug)
-        {
             if (stream == null)
                 return null;
 


### PR DESCRIPTION
Newest SharpCompress added support for extracting 7-Zip SFX files, so we can add support for them here too.

Relies on #320, or SharpCompress being updated to 0.38.0 otherwise. There appears to be a bug present where files in a folder inside of 7z archives aren't extracted, but this occurs with normal 7z archives in latest release as well and will be reported separately. So, this has been marked as "[WIP]" in-case changes need to be made to the extraction code in SFX as well. Alternatively, this can be merged and then the bug can be dealt with at a later time. 