### PR TITLE
Fix various archive formats not extracting folders

### DIFF
--- a/BinaryObjectScanner/FileType/RAR.cs
+++ b/BinaryObjectScanner/FileType/RAR.cs
@@ -50,7 +50,14 @@ namespace BinaryObjectScanner.FileType
                             if (entry.Key == null)
                                 continue;
 
+                            // If we have a partial entry due to an incomplete multi-part archive, skip it
+                            if (!entry.IsComplete)
+                                continue;
+
                             string tempFile = Path.Combine(tempPath, entry.Key);
+                            var directoryName = Path.GetDirectoryName(tempFile);
+                            if (directoryName != null && !Directory.Exists(directoryName))
+                                Directory.CreateDirectory(directoryName);
                             entry.WriteToFile(tempFile);
                         }
                         catch (Exception ex)

--- a/BinaryObjectScanner/FileType/SevenZip.cs
+++ b/BinaryObjectScanner/FileType/SevenZip.cs
@@ -50,7 +50,14 @@ namespace BinaryObjectScanner.FileType
                             if (entry.Key == null)
                                 continue;
 
+                            // If we have a partial entry due to an incomplete multi-part archive, skip it
+                            if (!entry.IsComplete)
+                                continue;
+
                             string tempFile = Path.Combine(tempPath, entry.Key);
+                            var directoryName = Path.GetDirectoryName(tempFile);
+                            if (directoryName != null && !Directory.Exists(directoryName))
+                                Directory.CreateDirectory(directoryName);
                             entry.WriteToFile(tempFile);
                         }
                         catch (Exception ex)

--- a/BinaryObjectScanner/FileType/TapeArchive.cs
+++ b/BinaryObjectScanner/FileType/TapeArchive.cs
@@ -50,7 +50,15 @@ namespace BinaryObjectScanner.FileType
                             if (entry.Key == null)
                                 continue;
 
+                            // If we have a partial entry due to an incomplete multi-part archive, skip it
+                            if (!entry.IsComplete)
+                                continue;
+
+                            // TODO: Fix bug with extracting folders from tar.
                             string tempFile = Path.Combine(tempPath, entry.Key);
+                            var directoryName = Path.GetDirectoryName(tempFile);
+                            if (directoryName != null && !Directory.Exists(directoryName))
+                                Directory.CreateDirectory(directoryName);
                             entry.WriteToFile(tempFile);
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Fixes folder extraction for 7z, RAR, and WinRAR SFX. Applied same fix to tar, but more is needed for it to work properly.