### PR TITLE
Move Armadillo to Protection and add notes

### DIFF
--- a/BinaryObjectScanner/Protection/Armadillo.cs
+++ b/BinaryObjectScanner/Protection/Armadillo.cs
@@ -2,11 +2,22 @@
 using BinaryObjectScanner.Interfaces;
 using SabreTools.Serialization.Wrappers;
 
-namespace BinaryObjectScanner.Packer
-{
+namespace BinaryObjectScanner.Protection
+{ 
+    /// <summary>
+    /// Armadillo was a license manager, packer, and DRM by "The Silicon Realm Toolworks": https://web.archive.org/web/20030203101931/http://www.siliconrealms.com/armadillo.shtml
+    /// They were later bought by Digital River, and updated their website: https://web.archive.org/web/20031203021152/http://www.siliconrealms.com/armadillo.shtml
+    /// A new updated version named "SoftwarePassport" was released: https://web.archive.org/web/20040423044529/http://siliconrealms.com/softwarepassport/popup.shtml
+    /// Later copy of the website, with SoftwarePassport being named instead of Armadillo: https://web.archive.org/web/20040804032608/http://www.siliconrealms.com/armadillo.shtml
+    /// It appears as though both Armadillo and SoftwarePassport were being released at the same time, possibly with Armadillo acting as the core component and SoftwarePassport being supplementary: https://web.archive.org/web/20050619013312/http://siliconrealms.com/srt-news.shtml
+    /// Digital River itself also advertised Armadillo at first: https://web.archive.org/web/20040116043029/http://www.digitalriver.com:80/corporate/solutions06.shtml
+    /// But then only advertised SoftwarePassport once it was released: https://web.archive.org/web/20040604065907/http://www.digitalriver.com/corporate/solutions06.shtml
+    /// </summary>
+    
     // TODO: Add extraction
     // TODO: Add version checking, if possible
     // https://raw.githubusercontent.com/wolfram77web/app-peid/master/userdb.txt
+    
     public class Armadillo : IExtractablePortableExecutable, IPortableExecutableCheck
     {
         /// <inheritdoc/>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Below is a list of protections detected by BinaryObjectScanner. The two columns 
 | AegiSoft License Manager | True | True | |
 | Alpha-DVD | False | True | Unconfirmed¹ |
 | Alpha-ROM | True | False | |
+| Armadillo | True | False | | 
 | Bitpool | False | True | |
 | ByteShield | True | True | |
 | C-Dilla License Management Solution / CD-Secure / CD-Compress | True | True | |
@@ -156,7 +157,6 @@ Below is a list of executable packers detected by BinaryObjectScanner. The three
 | .NET Reactor | Yes | No | No | |
 | 7-zip SFX | Yes | No | Yes | |
 | Advanced Installer / Caphyon Advanced Installer | Yes | No | No | |
-| Armadillo | Yes | No | No | |
 | ASPack | Yes | No | No | |
 | AutoPlay Media Studio | Yes | No | No | |
 | CExe | Yes | No | Yes | |


### PR DESCRIPTION
Armadillo has packer and protection features, meaning it should be move to be a protection. Also add additional notes, including about an alternate later name, "SoftwarePassport".