### PR TITLE
Add aditional copy-X light directory checks

### DIFF
--- a/BinaryObjectScanner/Protection/CopyX.cs
+++ b/BinaryObjectScanner/Protection/CopyX.cs
@@ -107,7 +107,7 @@ namespace BinaryObjectScanner.Protection
             // intersecting the start of the file.
 
             // Kenny's Adventure uses System instead of ZDAT.
-            string[] dirs = ["ZDAT", "ZDATA", "System"];
+            string[] dirs = ["ZDAT", "ZDATA", "ZZDAT", "ZZDATA", "ZYDAT", "ZYDATA", "System"];
             List<string>? lightFiles = null;
 
             // TODO: Compensate for the check being run a directory or more higher


### PR DESCRIPTION
Compensate for some additional variance in directory names found from new samples, in lieu of a more "advanced" check.