### PR TITLE
Improve Hexalock detection slightly

### DIFF
--- a/BinaryObjectScanner/Protection/HexalockAutoLock.cs
+++ b/BinaryObjectScanner/Protection/HexalockAutoLock.cs
@@ -61,7 +61,15 @@ namespace BinaryObjectScanner.Protection
             strs = pex.GetFirstSectionStrings("code") ?? pex.GetFirstSectionStrings("CODE");
             if (strs != null)
             {
-                // Found in "Sea Adventure / Adventure de la Mer" by Compedia
+                // Found in "launcher.exe" in "Sea Adventure / Adventure de la Mer" by Compedia.
+                if (strs.Exists(s => s.Contains("mfint.dll")))
+                    return "Hexalock Autolock";
+            }
+            // Get the UPX1 section strings, if they exist
+            strs = pex.GetFirstSectionStrings("UPX1");
+            if (strs != null)
+            {
+                // Found in "postmanpat.exe" in "Postman Pat" by Compedia.
                 if (strs.Exists(s => s.Contains("mfint.dll")))
                     return "Hexalock Autolock";
             }

--- a/BinaryObjectScanner/Protection/HexalockAutoLock.cs
+++ b/BinaryObjectScanner/Protection/HexalockAutoLock.cs
@@ -57,7 +57,15 @@ namespace BinaryObjectScanner.Protection
                 if (strs.Exists(s => s.Contains("mfint.dll")))
                     return "Hexalock Autolock";
             }
-
+            // Get the CODE section strings, if they exist
+            strs = pex.GetFirstSectionStrings("CODE");
+            if (strs != null)
+            {
+                // Found in "Sea Adventure / Adventure de la Mer" by Compedia
+                if (strs.Exists(s => s.Contains("mfint.dll")))
+                    return "Hexalock Autolock";
+            }
+            
             return null;
         }
 

--- a/BinaryObjectScanner/Protection/HexalockAutoLock.cs
+++ b/BinaryObjectScanner/Protection/HexalockAutoLock.cs
@@ -57,8 +57,8 @@ namespace BinaryObjectScanner.Protection
                 if (strs.Exists(s => s.Contains("mfint.dll")))
                     return "Hexalock Autolock";
             }
-            // Get the CODE section strings, if they exist
-            strs = pex.GetFirstSectionStrings("CODE");
+            // Get the code/CODE section strings, if they exist
+            strs = pex.GetFirstSectionStrings("code") ?? pex.GetFirstSectionStrings("CODE");
             if (strs != null)
             {
                 // Found in "Sea Adventure / Adventure de la Mer" by Compedia

--- a/BinaryObjectScanner/Protection/HexalockAutoLock.cs
+++ b/BinaryObjectScanner/Protection/HexalockAutoLock.cs
@@ -57,6 +57,7 @@ namespace BinaryObjectScanner.Protection
                 if (strs.Exists(s => s.Contains("mfint.dll")))
                     return "Hexalock Autolock";
             }
+            
             // Get the code/CODE section strings, if they exist
             strs = pex.GetFirstSectionStrings("code") ?? pex.GetFirstSectionStrings("CODE");
             if (strs != null)
@@ -65,6 +66,7 @@ namespace BinaryObjectScanner.Protection
                 if (strs.Exists(s => s.Contains("mfint.dll")))
                     return "Hexalock Autolock";
             }
+            
             // Get the UPX1 section strings, if they exist
             strs = pex.GetFirstSectionStrings("UPX1");
             if (strs != null)


### PR DESCRIPTION
My hexalock disc has mfint.dll in a different section of PE. This PR causes it to be detected where it wasn't before. Some of Morlit's discs also weren't detecting, likely for similar reasons, but I have still yet to get to those.