### PR TITLE
Removed secondary ASPack 1.08.04 check due to false positives.

### DIFF
--- a/BinaryObjectScanner/Packer/ASPack.cs
+++ b/BinaryObjectScanner/Packer/ASPack.cs
@@ -656,8 +656,9 @@ namespace BinaryObjectScanner.Packer
 
                 new(new byte?[] { 0x60, 0xE8, 0x41, 0x06, 0x00, 0x00, 0xEB, 0x41 }, "ASPack 1.08.04"),
 
-                new(new byte?[] { 0x60, 0xE8, null, null, null, null, 0xEB }, "ASPack 1.08.04"),
-
+                // Disabled due to being too prone to false positives. 
+                //new(new byte?[] { 0x60, 0xE8, null, null, null, null, 0xEB }, "ASPack 1.08.04"),
+                
                 new(new byte?[] { 0x60, 0xE8, 0x70, 0x05, 0x00, 0x00, 0xEB, 0x4C }, "ASPack 2.00.00"),
 
                 new(new byte?[] { 0x60, 0xE8, 0x48, 0x11, 0x00, 0x00, 0xC3, 0x83 }, "ASPack 2.00.00"),


### PR DESCRIPTION
See title. http://redump.org/disc/47205/ has an executable protected by PE-Crypt 1.02, not ASPack. Fairly certain this is a false positive due to the executable itself specifying it was protected with PE-Crypt.
![image](https://github.com/user-attachments/assets/145130a6-7acd-4223-a74d-7807195f1d03)
In general, this check seems prone to false positives anyways- two bytes, followed by any four bytes, followed by one more byte seems prone to other cases like this.
Please let me know if this change is not desired, or if an alternate fix is needed.