### PR TITLE
Add missed "Check disc for physical ring" in copy-X return

### DIFF
--- a/BinaryObjectScanner/Protection/CopyX.cs
+++ b/BinaryObjectScanner/Protection/CopyX.cs
@@ -134,7 +134,7 @@ namespace BinaryObjectScanner.Protection
 
                     // Samples: Redump ID 81628
                     if (Array.TrueForAll(block, b => b == 0))
-                        protections.Add("copy-X");
+                        protections.Add("copy-X [Check disc for physical ring]");
 
                     var matchers = new List<ContentMatchSet>
                     {


### PR DESCRIPTION
Caught by noigeaR, crucial to communicate since some tivola discs have dummy files but no ring (and thus no copy-X), either as remnants, or seemingly as future preparation for copy-X