### PR TITLE
Add PackerScan

### DIFF
--- a/PackerScan/Options.cs
+++ b/PackerScan/Options.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+
+namespace PackerScan
+{
+    /// <summary>
+    /// Set of options for the test executable
+    /// </summary>
+    internal sealed class Options
+    {
+        #region Properties
+
+        /// <summary>
+        /// Enable debug output for relevant operations
+        /// </summary>
+        public bool Debug { get; private set; } = false;
+
+        /// <summary>
+        /// Input path to use for detection
+        /// </summary>
+        public string? InputPath { get; private set; } = null;
+
+        /// <summary>
+        /// Scan for self-extracting archives too
+        /// </summary>
+        public bool ScanArchives { get; private set; } = true;
+
+        /// <summary>
+        /// Scan for installers too
+        /// </summary>
+        public bool ScanInstallers { get; private set; } = true;
+
+        /// <summary>
+        /// Scan for other things like embedded archives or executables too
+        /// </summary>
+        public bool ScanOthers { get; private set; } = true;
+
+        #endregion
+
+        /// <summary>
+        /// Parse commandline arguments into an Options object
+        /// </summary>
+        public static Options? ParseOptions(string[] args)
+        {
+            // If we have invalid arguments
+            if (args == null || args.Length == 0)
+                return null;
+
+            // Create an Options object
+            var options = new Options();
+
+            // Parse the options and paths
+            for (int index = 0; index < args.Length; index++)
+            {
+                string arg = args[index];
+                switch (arg)
+                {
+                    case "-?":
+                    case "-h":
+                    case "--help":
+                        return null;
+
+                    case "-d":
+                    case "--debug":
+                        options.Debug = true;
+                        break;
+
+                    case "-na":
+                    case "--no-archives":
+                        options.ScanArchives = false;
+                        break;
+
+                    case "-ni":
+                    case "--no-installers":
+                        options.ScanInstallers = false;
+                        break;
+
+                    case "-no":
+                    case "--no-others":
+                        options.ScanOthers = false;
+                        break;
+
+                    default:
+                        options.InputPath = arg;
+                        break;
+                }
+            }
+            
+            // Validate we have any input paths to work on
+            if (options.InputPath == null)
+            {
+                Console.WriteLine("Please provide an input Portable Executable");
+                return null;
+            }
+
+            return options;
+        }
+
+        /// <summary>
+        /// Display help text
+        /// </summary>
+        public static void DisplayHelp()
+        {
+            Console.WriteLine("Packer Scanner");
+            Console.WriteLine();
+            Console.WriteLine("PackerScan.exe <options> file|directory ...");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("-?, -h, --help           Display this help text and quit");
+            Console.WriteLine("-d, --debug              Enable debug mode");
+            Console.WriteLine("-na, --no-archives       Disable scanning for self-extracting archives");
+            Console.WriteLine("-ni, --no-installers     Disable scanning for installers");
+            Console.WriteLine("-no, --no-others         Disable scanning for other artifacts like embedded archives or executables");
+        }
+    }
+}

--- a/PackerScan/PackerScan.csproj
+++ b/PackerScan/PackerScan.csproj
@@ -1,0 +1,64 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net20;net35;net40;net452;net462;net472;net48;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <OutputType>Exe</OutputType>
+        <CheckEolTargetFramework>false</CheckEolTargetFramework>
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <Version>3.3.4</Version>
+    </PropertyGroup>
+
+    <!-- Support All Frameworks -->
+    <PropertyGroup Condition="$(TargetFramework.StartsWith(`net2`)) OR $(TargetFramework.StartsWith(`net3`)) OR $(TargetFramework.StartsWith(`net4`))">
+        <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(TargetFramework.StartsWith(`netcoreapp`)) OR $(TargetFramework.StartsWith(`net5`))">
+        <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64</RuntimeIdentifiers>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(TargetFramework.StartsWith(`net6`)) OR $(TargetFramework.StartsWith(`net7`)) OR $(TargetFramework.StartsWith(`net8`)) OR $(TargetFramework.StartsWith(`net9`))">
+        <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith(`osx-arm`))">
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <!-- These are needed for dealing with native Windows DLLs -->
+    <ItemGroup Condition="'$(RuntimeIdentifier)'=='win-x86'">
+        <ContentWithTargetPath Include="..\BinaryObjectScanner\runtimes\win-x86\native\CascLib.dll">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+            <TargetPath>CascLib.dll</TargetPath>
+        </ContentWithTargetPath>
+        <ContentWithTargetPath Include="..\BinaryObjectScanner\runtimes\win-x86\native\mspack.dll">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+            <TargetPath>mspack.dll</TargetPath>
+        </ContentWithTargetPath>
+        <ContentWithTargetPath Include="..\BinaryObjectScanner\runtimes\win-x86\native\StormLib.dll">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+            <TargetPath>StormLib.dll</TargetPath>
+        </ContentWithTargetPath>
+    </ItemGroup>
+    <ItemGroup Condition="'$(RuntimeIdentifier)'=='win-x64'">
+        <ContentWithTargetPath Include="..\BinaryObjectScanner\runtimes\win-x64\native\CascLib.dll">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+            <TargetPath>CascLib.dll</TargetPath>
+        </ContentWithTargetPath>
+        <ContentWithTargetPath Include="..\BinaryObjectScanner\runtimes\win-x64\native\StormLib.dll">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+            <TargetPath>StormLib.dll</TargetPath>
+        </ContentWithTargetPath>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\BinaryObjectScanner\BinaryObjectScanner.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/PackerScan/Program.cs
+++ b/PackerScan/Program.cs
@@ -1,0 +1,330 @@
+﻿using System;
+using System.IO;
+using BinaryObjectScanner.FileType;
+using BinaryObjectScanner.Packer;
+using SabreTools.IO.Extensions;
+using WrapperFactory = SabreTools.Serialization.Wrappers.WrapperFactory;
+using WrapperType = SabreTools.Serialization.Wrappers.WrapperType;
+
+namespace PackerScan
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+#if NET462_OR_GREATER || NETCOREAPP
+            // Register the codepages
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+#endif
+
+            // Get the options from the arguments
+            var options = Options.ParseOptions(args);
+
+            // If we have an invalid state
+            if (options == null)
+            {
+                Options.DisplayHelp();
+                return;
+            }
+
+            // Detect packers on the input file
+            DetectPackers(options.InputPath, options.ScanArchives, options.ScanInstallers, options.ScanOthers, options.Debug);
+        }
+
+        /// <summary>
+        /// Wrapper to detect packers for a single path
+        /// </summary>
+        /// <param name="path">File or directory path</param>
+        /// <param name="includeDebug">Enable including debug information</param>
+        private static void DetectPackers(string? file, bool scanArchives, bool scanInstallers, bool scanOthers, bool includeDebug)
+        {
+            if (file == null)
+            {
+                return;
+            }
+            
+            using Stream stream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            // Get the extension for certain checks
+            string extension = Path.GetExtension(file).ToLower().TrimStart('.');
+
+            // Get the first 16 bytes for matching
+            byte[] magic = new byte[16];
+            try
+            {
+                int read = stream.Read(magic, 0, 16);
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+            catch (Exception ex)
+            {
+                if (includeDebug) Console.WriteLine(ex);
+                return;
+            }
+
+            // Get the file type
+            WrapperType ft = WrapperFactory.GetFileType(magic, extension);
+
+            if (ft == WrapperType.Executable)
+            {
+                // Checking for packers
+                var exe = WrapperFactory.CreateExecutableWrapper(stream);
+
+                if (exe == null || exe is not SabreTools.Serialization.Wrappers.PortableExecutable pex)
+                {
+                    Console.WriteLine("[WARNING] Only portable executables are supported");
+                    Console.WriteLine();
+                    return;
+                }
+                
+                string? match;
+
+                // ASPack
+                var aspack = new ASPack();
+                match = aspack.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // CEXE
+                var cexe = new CExe();
+                match = cexe.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // Crunch
+                var crunch = new Crunch();
+                match = crunch.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // DotFuscator
+                var dotfuscator = new DotFuscator();
+                match = dotfuscator.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // DotNetReactor
+                var dotnetreactor = new DotNetReactor();
+                match = dotnetreactor.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // EXEStealth
+                var exestealth = new EXEStealth();
+                match = exestealth.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // HyperTechCrackProof
+                var htcp = new HyperTechCrackProof();
+                match = htcp.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // NeoLite
+                var neolite = new NeoLite();
+                match = neolite.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // PECompact
+                var pecompact = new PECompact();
+                match = pecompact.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // PEtite
+                var petite = new PEtite();
+                match = petite.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // Shrinker
+                var shrinker = new Shrinker();
+                match = shrinker.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                // UPX
+                var upx = new UPX();
+                match = upx.CheckExecutable(file, pex, includeDebug);
+                if (match != null)
+                {
+                    Console.WriteLine(match);
+                }
+
+                if (scanArchives == true)
+                {
+                    // Checking for self-extracting archives
+
+                    // MicrosoftCABSFX
+                    var mscabsfx = new MicrosoftCABSFX();
+                    match = mscabsfx.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // SevenZipSFX
+                    var sevenzipsfx = new SevenZipSFX();
+                    match = sevenzipsfx.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // WinRARSFX
+                    var winrarsfx = new WinRARSFX();
+                    match = winrarsfx.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // WinZipSFX
+                    var winzipsfx = new WinZipSFX();
+                    match = winzipsfx.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+                }
+
+                if (scanInstallers == true)
+                {
+                    // Checking for installers
+
+                    // AdvancedInstaller
+                    var advancedinstaller = new AdvancedInstaller();
+                    match = advancedinstaller.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // GenteeInstaller
+                    var genteeinstaller = new GenteeInstaller();
+                    match = genteeinstaller.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // InnoSetup
+                    var innosetup = new InnoSetup();
+                    match = innosetup.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // InstallAnywhere
+                    var installanywhere = new InstallAnywhere();
+                    match = installanywhere.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // InstallerVISE
+                    var installervise = new InstallerVISE();
+                    match = installervise.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // IntelInstallationFramework
+                    var intelif = new IntelInstallationFramework();
+                    match = intelif.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // NSIS
+                    var nsis = new NSIS();
+                    match = nsis.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // SetupFactory
+                    var setupfactory = new SetupFactory();
+                    match = setupfactory.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // WiseInstaller
+                    var wiseinstaller = new WiseInstaller();
+                    match = wiseinstaller.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+                }
+
+                if (scanOthers == true)
+                {
+                    // Checking for other things like embedded archives or executables
+
+                    // AutoPlayMediaStudio
+                    var apmstudio = new AutoPlayMediaStudio();
+                    match = apmstudio.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // EmbeddedArchive
+                    var embeddedarchive = new EmbeddedArchive();
+                    match = embeddedarchive.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+
+                    // EmbeddedExecutable
+                    var embeddedexecutable = new EmbeddedExecutable();
+                    match = embeddedexecutable.CheckExecutable(file, pex, includeDebug);
+                    if (match != null)
+                    {
+                        Console.WriteLine(match);
+                    }
+                }
+            }
+            
+            // Not a Portable Executable
+            else
+            {
+                Console.WriteLine("[ERROR] Not a Portable Executable");
+                Console.WriteLine();
+                return;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build and Test](https://github.com/SabreTools/BinaryObjectScanner/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/SabreTools/BinaryObjectScanner/actions/workflows/build_and_test.yml)
 
-C# protection, packer, and archive scanning library. This currently compiles as a library so it can be used in any C# application. Two reference applications called `ProtectionScan` and `ExtractionTool` are also included to demonstrate the abilities of the library. For an example of a program implementing the library, see [MPF](https://github.com/SabreTools/MPF).
+C# protection, packer, and archive scanning library. This currently compiles as a library so it can be used in any C# application. Three reference applications called `ProtectionScan`, `PackerScan` and `ExtractionTool` are also included to demonstrate the abilities of the library. For an example of a program implementing the library, see [MPF](https://github.com/SabreTools/MPF).
 
 The following non-project libraries (or ports thereof) are used for file handling:
 


### PR DESCRIPTION
Added a third reference application beside `ProtectionScan` and `ExtractionTool` called `PackerScan` that provides a CLI tool to scan for packers from [`BinaryObjectScanner.Packer`](https://github.com/SabreTools/BinaryObjectScanner/tree/master/BinaryObjectScanner/Packer).

**Summary of changes**

- New `PackerScan` folder with a program based on `ProtectionScan` and adapted with the `BinaryObjectScanner.Packer` API
- `publish-nix.sh` and `publish-win.ps1` scripts adapted to also build `PackerScan` and create packages
- `README.md` adapted to include the third application in the first paragraph.