### PR TITLE
make paul.dll internal name check non-case-sensitive

### DIFF
--- a/BinaryObjectScanner/Protection/SecuROM.cs
+++ b/BinaryObjectScanner/Protection/SecuROM.cs
@@ -19,7 +19,7 @@ namespace BinaryObjectScanner.Protection
                 return $"SecuROM Product Activation v{pex.GetInternalVersion()}";
 
             name = pex.InternalName;
-            if (name.OptionalEquals("paul.dll"))
+            if (name.OptionalEquals("paul.dll", StringComparison.OrdinalIgnoreCase))
                 return $"SecuROM Product Activation v{pex.GetInternalVersion()}";
             else if (name.OptionalEquals("paul_dll_activate_and_play.dll"))
                 return $"SecuROM Product Activation v{pex.GetInternalVersion()}";


### PR DESCRIPTION
Sometimes the internal name is in all caps, like http://redump.org/disc/115608/ and http://redump.org/disc/47171/