### PR TITLE
Add EA Game Authorization Management checking to paul.dll

### DIFF
--- a/BinaryObjectScanner/Protection/SecuROM.cs
+++ b/BinaryObjectScanner/Protection/SecuROM.cs
@@ -21,6 +21,8 @@ namespace BinaryObjectScanner.Protection
 
             name = pex.InternalName;
             if (name.OptionalEquals("paul.dll", StringComparison.OrdinalIgnoreCase))
+                if (pex.ProductName.OptionalEquals("drEAm"))
+                    return $"SecuROM Product Activation v{pex.GetInternalVersion()} - EA Game Authorization Management";
                 return $"SecuROM Product Activation v{pex.GetInternalVersion()}";
             else if (name.OptionalEquals("paul_dll_activate_and_play.dll"))
                 return $"SecuROM Product Activation v{pex.GetInternalVersion()}";


### PR DESCRIPTION
EA games have their own special custom version of PA https://activate.ea.com/deauthorize/ that functions differently and also has to be bypassed differently (doesn't matter for BOS obviously, but, just stating it because it's notable enough that it should be detected). Sample is most EA games with PA, but Burnout Paradise and Battlefield Bad Company 2 are quick examples. Easiest way to check is just to see if the product name is "drEAm". Not currently aware of any that differ from this.

Infoprint output of the one from BC2 for documentation purposes.
[info-2025-05-06_152942.1993.txt](https://github.com/user-attachments/files/20069579/info-2025-05-06_152942.1993.txt)
