### PR TITLE
Improve detection for cd/dvd-cops version string

### DIFF
--- a/BinaryObjectScanner.Test/Protection/CDDVDCopsTests.cs
+++ b/BinaryObjectScanner.Test/Protection/CDDVDCopsTests.cs
@@ -8,17 +8,6 @@ namespace BinaryObjectScanner.Test.Protection
     public class CDDVDCopsTests
     {
         [Fact]
-        public void CheckContentsTest()
-        {
-            string file = "filename";
-            byte[] fileContent = [0x01, 0x02, 0x03, 0x04];
-
-            var checker = new CDDVDCops();
-            string? actual = checker.CheckContents(file, fileContent, includeDebug: true);
-            Assert.Null(actual);
-        }
-
-        [Fact]
         public void CheckNewExecutableTest()
         {
             string file = "filename";

--- a/BinaryObjectScanner/Protection/CDDVDCops.cs
+++ b/BinaryObjectScanner/Protection/CDDVDCops.cs
@@ -266,7 +266,7 @@ namespace BinaryObjectScanner.Protection
         private static string GetVersionString(string match)
         {
             // Full string ends with # (i.e. "CD-Cops,  ver. 1.72,  #"), use that to compensate for comma in version 
-            // number cases (don't change the comma, see earlier to-do) like "DVD-Cops, ver. 1,60,"
+            // number cases (don't change the comma, see earlier to-do) like "DVD-Cops, ver. 1,60,  #"
             // TODO: improve regex via the starting "N" character? Possibly unnecessary?
             var versionMatch = Regex.Match(match, @"(?<=D-Cops,\s{1,}ver. )(.*?)(?=,\s{1,}#)");
             if (versionMatch.Success)

--- a/BinaryObjectScanner/Protection/CDDVDCops.cs
+++ b/BinaryObjectScanner/Protection/CDDVDCops.cs
@@ -83,22 +83,21 @@ namespace BinaryObjectScanner.Protection
             var neMatchSets = new List<ContentMatchSet>
             {
                 // Checking for variants with one or two spaces, just in case; the Brockhaus DVDs only had one
-                // CD-Cops, ver. 
                 new(new byte?[]
                 {
                     0x43, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73, 0x2C,
                     0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                }, GetVersion, "CD-Cops (Unconfirmed - Please report to us on Github)"),
+                }, GetVersion, "CD-Cops"),
+                // CD-Cops, ver. 
                 
-                // CD-Cops,  ver. 
                 // Found in "h3blade.exe" in Redump entry 85077.
                 new(new byte?[]
                 {
                     0x43, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73, 0x2C,
                     0x20, 0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                }, GetVersion, "CD-Cops (Unconfirmed - Please report to us on Github)"),
+                }, GetVersion, "CD-Cops"),
+                // CD-Cops,  ver. 
 
-                // DVD-Cops, ver. 
                 // Found in IA entries "der-brockhaus-multimedial-2002-premium" and "der-brockhaus-multimedial-2003-premium"
                 // TODO: 2002 returns DVD-Cops 2.01, 2003 returns DVD-Cops 1,60. CD-Cops version numbers seem to "reset" 
                 // after some point in time in existing redump entries- perhaps the command instead of the period may have
@@ -107,14 +106,15 @@ namespace BinaryObjectScanner.Protection
                 {
                     0x44, 0x56, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73,
                     0x2C, 0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                }, GetVersion, "DVD-Cops (Unconfirmed - Please report to us on Github)"),
+                }, GetVersion, "DVD-Cops"),
+                // DVD-Cops, ver. 
                 
-                // DVD-Cops,  ver. 
                 new(new byte?[]
                 {
                     0x44, 0x56, 0x44, 0x2D, 0x43, 0x6F, 0x70, 0x73,
                     0x2C, 0x20, 0x20, 0x76, 0x65, 0x72, 0x2E, 0x20
-                }, GetVersion, "DVD-Cops (Unconfirmed - Please report to us on Github)"),
+                }, GetVersion, "DVD-Cops"),
+                // DVD-Cops,  ver. 
             };
 
             var match = MatchUtil.GetFirstMatch(file, data, neMatchSets, includeDebug);
@@ -225,6 +225,16 @@ namespace BinaryObjectScanner.Protection
 
                 new(new PathMatch(".GZ_", matchCase: true, useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
                 new(new PathMatch(".Qz", matchCase: true, useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
+                
+                // Found in Redump entries 84517, 108167, 119435, 119436, and 119437. This is the official
+                // name from their website https://www.linkdatasecurity.com/index.htm#/protection-products/cd-dvd-usb-copy-protection/cdcops
+                // I can't find this specific filename documented anywhere, but, all of these
+                // games do not require a key to be input
+                new(new FilePathMatch("cdcode.key"), "CD-Cops Codefree"),
+                
+                // DVD-Cops Codefree does exist https://www.linkdatasecurity.com/index.htm#/protection-products/cd-dvd-usb-copy-protection/dvdvers
+                // but we currently have no samples. Presumably this is what the file would be called?
+                new(new FilePathMatch("dvdcode.key"), "DVD-Cops Codefree (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetAllMatches(files, matchers, any: true);
@@ -245,6 +255,15 @@ namespace BinaryObjectScanner.Protection
 
                 new(new PathMatch(".GZ_", matchCase: true, useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
                 new(new PathMatch(".Qz", matchCase: true, useEndsWith: true), "CD-Cops (Unconfirmed - Please report to us on Github)"),
+                // Found in Redump entries 84517, 108167, 119435, 119436, and 119437. This is the official
+                // name from their website https://www.linkdatasecurity.com/index.htm#/protection-products/cd-dvd-usb-copy-protection/cdcops
+                // I can't find this specific filename documented anywhere, but, all of these
+                // games do not require a key to be input
+                new(new FilePathMatch("cdcode.key"), "CD-Cops Codefree"),
+                
+                // DVD-Cops Codefree does exist https://www.linkdatasecurity.com/index.htm#/protection-products/cd-dvd-usb-copy-protection/dvdvers
+                // but we currently have no samples. Presumably this is what the file would be called?
+                new(new FilePathMatch("dvdcode.key"), "DVD-Cops Codefree (Unconfirmed - Please report to us on Github)"),
             };
 
             return MatchUtil.GetFirstMatch(path, matchers, any: true);

--- a/BinaryObjectScanner/Protection/CDDVDCops.cs
+++ b/BinaryObjectScanner/Protection/CDDVDCops.cs
@@ -265,7 +265,10 @@ namespace BinaryObjectScanner.Protection
         
         private static string GetVersionString(string match)
         {
-            var versionMatch = Regex.Match(match, @"(?<=D-Cops,\s{1,}ver. )(.*?)(?=,)");
+            // Full string ends with # (i.e. "CD-Cops,  ver. 1.72,  #"), use that to compensate for comma in version 
+            // number cases (don't change the comma, see earlier to-do) like "DVD-Cops, ver. 1,60,"
+            // TODO: improve regex via the starting "N" character? Possibly unnecessary?
+            var versionMatch = Regex.Match(match, @"(?<=D-Cops,\s{1,}ver. )(.*?)(?=,\s{1,}#)");
             if (versionMatch.Success)
                 return versionMatch.Value;
             


### PR DESCRIPTION
This removes the content check, moves the NE checks to the NE check section, and adds a PE check for the single currently confirmed section. 

One thing I was wondering- what's with the "(Unconfirmed - Please report to us on Github)" parts? They seem pretty confirmed, even being in existing redump entries. Is it supposed to be a placeholder for a safedisc-style version table?

```
/home/bestest/cdCopsSamples/2002MM/BMM.exe: DVD-Cops (Unconfirmed - Please report to us on Github) 2.01
/home/bestest/cdCopsSamples/2003MM/bmm.exe: DVD-Cops (Unconfirmed - Please report to us on Github) 1,60
/home/bestest/cdCopsSamples/aHugEu/AgentHugo.exe: CD-Cops (Unconfirmed - Please report to us on Github) 1,08
/home/bestest/cdCopsSamples/bib/bib.dll: CD-Cops 1.95
/home/bestest/cdCopsSamples/mofamen/h3blade.exe: CD-Cops (Unconfirmed - Please report to us on Github) 1.72
```

Fixes https://github.com/SabreTools/BinaryObjectScanner/issues/367