### PR TITLE
Add check for modified securom product activation. 

### DIFF
--- a/BinaryObjectScanner/Protection/SecuROM.cs
+++ b/BinaryObjectScanner/Protection/SecuROM.cs
@@ -5,6 +5,8 @@ using BinaryObjectScanner.Interfaces;
 using SabreTools.Matching;
 using SabreTools.Matching.Content;
 using SabreTools.Matching.Paths;
+using SabreTools.Models.PortableExecutable;
+using SabreTools.Serialization;
 using SabreTools.Serialization.Wrappers;
 
 namespace BinaryObjectScanner.Protection
@@ -44,6 +46,18 @@ namespace BinaryObjectScanner.Protection
             if (name.OptionalContains("SecuROM Activate & Play"))
                 return $"SecuROM Product Activation v{pex.GetInternalVersion()}";
 
+            // Fallback for PA if none of the above occur, in the case of companies that used their own modified PA
+            // variants. PiD refers to this as "SecuROM Modified PA Module".
+            // Found in Redump entries 111997 (paul.dll) and 56373+56374 (AurParticleSystem.dll). The developers of 
+            // both, Softstar and Aurogon respectively(?), seem to have some connection, and use similar-looking
+            // modified PA. It probably has its own name like EA's GAM, but I don't currently know what that would be. 
+            // Regardless, even if these are given their own named variant later, this check should remain in order to
+            // catch other modified PA variants (this would have also caught EA GAM, for example) and to match PiD's 
+            // detection abilities.
+            name = pex.Model.ExportTable?.ExportNameTable?.Strings?[0];
+            if (name.OptionalEquals("drm_pagui_doit"))
+                return $"SecuROM Product Activation - Modified";
+            
             // Get the matrosch section, if it exists
             if (pex.ContainsSection("matrosch", exact: true))
                 return $"SecuROM Matroschka Package";


### PR DESCRIPTION
Added check for modified securom product activation. Marked as draft because it relies on a recent infotool fix https://github.com/SabreTools/SabreTools.Serialization/commit/d3e61b42dd41c7d43496a0dde7e57be7accd32f7 in order to function properly, and submitted now because I'm going to forget to do it later.