### PR TITLE
Add versioning to FrontLine ProActive 

### DIFF
--- a/BinaryObjectScanner/Protection/StarForce.cs
+++ b/BinaryObjectScanner/Protection/StarForce.cs
@@ -61,7 +61,7 @@ namespace BinaryObjectScanner.Protection
             // https://dbox.tools/titles/pc/53450FA1/
             name = exe.TradeName;
             if (name.OptionalContains("FL ProActive"))
-                return $"FrontLine ProActive {exe.GetInternalVersion()}";
+                return $"StarForce FrontLine ProActive {exe.GetInternalVersion()}";
 
             // StarForce Crypto (SF Crypto)
             // Found in "pcnsl.exe" in Redump entry 119679

--- a/BinaryObjectScanner/Protection/StarForce.cs
+++ b/BinaryObjectScanner/Protection/StarForce.cs
@@ -59,11 +59,13 @@ namespace BinaryObjectScanner.Protection
             // https://dbox.tools/titles/pc/46450FA4/ 
             // https://dbox.tools/titles/pc/4F430FA0/ 
             // https://dbox.tools/titles/pc/53450FA1/
+            name = exe.TradeName;
             if (name.OptionalContains("FL ProActive"))
-                return "FrontLine ProActive";
+                return $"FrontLine ProActive {exe.GetInternalVersion()}";
 
             // StarForce Crypto (SF Crypto)
             // Found in "pcnsl.exe" in Redump entry 119679
+            // TODO: return version?
             if (name.OptionalContains("SF Crypto"))
                 return "StarForce Crypto";
 


### PR DESCRIPTION
It uses the same versioning as non-proactive starforce, and it was incredibly lazy of me to add it in the first place without that.
In general, this check is awful, and I want to try and overhaul starforce online-activation-related stuff anyways, but I've got a lot on my plate before then.